### PR TITLE
Improved start and stop scripts by removing dependency on PIDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,26 +6,37 @@ Clone the repository:
 $ git clone https://github.com/CLIMB-COVID/vafdb.git
 $ cd vafdb/
 ```
-Create and activate the `vafdb` conda environment:
-```
-$ conda env create -f environment.yml
-$ conda activate vafdb
-```
-Run the `setup.sh` script to build the client and initialise the database:
+Run the `setup.sh` script. This creates the `vafdb` conda environment, initialises the database and builds the client program:
 ```
 $ ./setup.sh
 ```
-Then, to start the `vafdb` server, run the `start.sh` script:
+To start the `vafdb` server, run the `start.sh` script:
 ```
 $ ./start.sh
-Starting PIDs: 15292 15293 15294
 VAFDB started.
 ```
 To stop the `vafdb` server, run the `stop.sh` script:
 ```
 $ ./stop.sh
-Stopping PIDs: 15292 15293 15294
 VAFDB stopped.
+```
+Once the conda environment is activated, the client program can be used:
+```
+$ conda activate vafdb
+$ vafdb -h
+usage: vafdb [-h] [--host HOST] [--port PORT] [-v] {command} ...
+
+positional arguments:
+  {command}
+    generate     Generate VAFs from metadata.
+    filter       Filter VAFs and their metadata.
+    delete       Delete VAFs and their metadata.
+
+options:
+  -h, --help     show this help message and exit
+  --host HOST    Host of VAFDB instance. Default: localhost
+  --port PORT    Port number of VAFDB instance. Default: 8000
+  -v, --version  Client version number.
 ```
 
 ## Projects
@@ -114,13 +125,13 @@ $ vafdb generate example_project --tsv metadata.tsv
 ```
 
 ## Retrieve data from a project
-Filter data via the CLI, and send the results to a file:
+Filter data via the CLI with `vafdb filter`, and send the results to a file:
 ```
 $ vafdb filter example_project --field reference chrom1 --field position__range 250,300 > vafs.tsv
 $ vafdb filter example_project --field sample_id E2A89A963D > vafs.tsv
 $ vafdb filter example_project --field position 500 --field collection_date__gt 2023-01-01 > vafs.tsv
 ```
-Execute complex filtering via the python client API:
+Execute complex filtering via the python client API with `vafdb query`:
 ```python
 # script.py
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,9 +2,11 @@
 cd "${0%/*}"
 mkdir -p logs
 eval "$(conda shell.bash hook)"
+conda env create -f environment.yml
 conda activate vafdb
-pip install ./client/
 cd vafdb
 python manage.py makemigrations
 python manage.py migrate
+cd ..
+pip install ./client/
 echo "VAFDB setup complete."

--- a/start.sh
+++ b/start.sh
@@ -4,9 +4,7 @@ cd "${0%/*}"
 eval "$(conda shell.bash hook)"
 conda activate vafdb
 cd vafdb/
-gunicorn vafdb.wsgi -c gunicorn.conf.py > ../logs/server.log 2>&1 & SERVER_PID=$!
-celery -A vafdb worker -Q generate_queue --concurrency=5 -l INFO -n GENERATE_NODE@%%h > ../logs/generate.log 2>&1 & GENERATE_PID=$!
-celery -A vafdb worker -Q store_queue --concurrency=1 -l INFO -n STORE_NODE@%%ha3 > ../logs/store.log 2>&1 & STORE_PID=$!
-echo "Starting PIDs: ${SERVER_PID} ${GENERATE_PID} ${STORE_PID}"
-echo "${SERVER_PID} ${GENERATE_PID} ${STORE_PID}" > ../logs/vafdb.pids
+gunicorn vafdb.wsgi -c gunicorn.conf.py > ../logs/server.log 2>&1 &
+celery -A vafdb worker -Q generate_queue --concurrency=5 -l INFO -n GENERATE_NODE@%%h > ../logs/generate.log 2>&1 &
+celery -A vafdb worker -Q store_queue --concurrency=1 -l INFO -n STORE_NODE@%%ha3 > ../logs/store.log 2>&1 &
 echo "VAFDB started."

--- a/stop.sh
+++ b/stop.sh
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-cd "${0%/*}"
-VAFDB_PIDS=`cat logs/vafdb.pids`
-echo "Stopping PIDs: ${VAFDB_PIDS}"
-kill $VAFDB_PIDS
+pkill -f "gunicorn vafdb.wsgi"
+pkill -f "celery -A vafdb"
 echo "VAFDB stopped."


### PR DESCRIPTION
- `start.sh` and `stop.sh` now use `pkill -f` to kill processes by name rather than PID.
- `setup.sh` now creates the conda environment.
- Updated `README.md` to match this.